### PR TITLE
Improving 'build_permutation_matrix' and fixing a bug in 'image_processing'

### DIFF
--- a/examples/Marmousi2D_VariableDensity.py
+++ b/examples/Marmousi2D_VariableDensity.py
@@ -122,8 +122,8 @@ if __name__ == '__main__':
 
     loop_configuration=[(30,{'frequencies' : [1,1.5,2.0,2.5] }),(30,{'frequencies' : [3.0,3.5,4.0,4.5] }), (20,{'frequencies' : [5,5.5,6.0,6.5] }),(20,{'frequencies' : [7.0,7.5,8.0,8.5] }), (20,{'frequencies' : [9,10,11,12] }), (20,{'frequencies' : [13,13.5,14,14.5]}),(20,{'frequencies' : [15,16,17,18]}), (20,{'frequencies' : [19,20,21,22,23,24,25,26,27,28,29,30]})] #3 steps at one set of frequencies and 3 at another set
 
-    result = invalg(shots, initial_value, loop_configuration, verbose=True, status_configuration=status_configuration, petsc='mkl_pardiso')
-
+    #result = invalg(shots, initial_value, loop_configuration, verbose=True, status_configuration=status_configuration, petsc='mkl_pardiso')
+    result = invalg(shots, initial_value, loop_configuration, verbose=True, status_configuration=status_configuration, petsc='mumps')
     print '...run time:  {0}s'.format(time.time()-tt)
 
     obj_vals = np.array([v for k,v in invalg.objective_history.items()])

--- a/pysit/util/derivatives/derivatives.py
+++ b/pysit/util/derivatives/derivatives.py
@@ -229,13 +229,27 @@ def build_permutation_matrix(nz,nx):
     # This creates a permutation matrix which transforms a column vector of nx
     # "component" columns of size nz, to the corresponding column vector of nz
     # "component" columns of size nx.
-    P=np.zeros((nz*nx,nz*nx))
-    v=np.zeros(nz*nx)
-    for i in xrange(nz):
-        for j in xrange(nx):
-            P[nx*i+j][:]=v
-            P[nx*i+j][i+j*nz]=1
-    return spsp.csr_matrix(P)
+    
+    def generate_matrix(nz, nx): #local function
+        P = spsp.lil_matrix((nz*nx,nz*nx)) 
+        for i in xrange(nz): #Looping is not efficient, but we only need to do it once as setup
+            for j in xrange(nx):
+                P[nx*i+j,i+j*nz]=1
+    
+        return P.tocsr()
+    
+    #Start body of code for 'build_permutation_matrix'
+    try: #See if there are already stored results from previous calls to this function
+        current_storage_dict = build_permutation_matrix.storage_dict
+    except: #If not, initialize
+        current_storage_dict = dict()
+        build_permutation_matrix.storage_dict = current_storage_dict
+    
+    if (nz,nx) not in current_storage_dict.keys(): #Have not precomputed this!
+        mat = generate_matrix(nz,nx)
+        current_storage_dict[nz,nx] = mat
+ 
+    return current_storage_dict[nz,nx]
 
 def build_offcentered_alpha(sh,alpha):
     # This computes the midpoints of alpha which will be used in the heterogenous laplacian

--- a/pysit/util/image_processing.py
+++ b/pysit/util/image_processing.py
@@ -79,7 +79,7 @@ def blur_image(im, sigma=None, freq=None, mesh_deltas=None, n_sigma=1.0):
         sigma = 1./freq
 
     # determine the size, in pixels, of the kernel
-    kernel_size_pixel = np.ceil(n_sigma*sigma / mesh_deltas)
+    kernel_size_pixel = (np.ceil(n_sigma*sigma / mesh_deltas)).astype('int32')
 
     kernel = gaussian_kernel(kernel_size_pixel, sigma, mesh_deltas)
 


### PR DESCRIPTION
I drastically improved the function 'build_permutation_matrix'. This function was slowing down variable density simulations significantly. First of all, a combination of 'nx' and 'nz' would generate a matrix no matter if a matrix for that combination of 'nx' and 'nz' had already been generated in the past. In order to prevent this additional work (which was not negligible) I decided to use a static function variable. 

The matrix generation code has also been improved.  The original code created a dense nx*nz by nx*nz matrix (size of hessian!) which took a lot of time and sometimes completely filled the memory, causing the code to crash. The way the original code filled this very sparse matrix was by added a dense vector to each row of the dense matrix, which only updated one single element. Directly accessing the element of the matrix is much faster. Since the matrix is sparse, I am working with sparse matrices from the start. I use lil_matrix when the sparsity structure still changes, and then change it to csr when I'm done. I tested that the resulting matrix is the same as what the original code produced. We just get the same result MUCH faster now.

I also fixed a bug in the util/image_processing.py where an array of float values was passed to np.pad, causing a crash on the new numpy versions. Before making this fix, the Marmousi example would not run for me.