### PR TITLE
Variable density higher orders accuracy

### DIFF
--- a/examples/Marmousi2D_VariableDensity.py
+++ b/examples/Marmousi2D_VariableDensity.py
@@ -122,8 +122,8 @@ if __name__ == '__main__':
 
     loop_configuration=[(30,{'frequencies' : [1,1.5,2.0,2.5] }),(30,{'frequencies' : [3.0,3.5,4.0,4.5] }), (20,{'frequencies' : [5,5.5,6.0,6.5] }),(20,{'frequencies' : [7.0,7.5,8.0,8.5] }), (20,{'frequencies' : [9,10,11,12] }), (20,{'frequencies' : [13,13.5,14,14.5]}),(20,{'frequencies' : [15,16,17,18]}), (20,{'frequencies' : [19,20,21,22,23,24,25,26,27,28,29,30]})] #3 steps at one set of frequencies and 3 at another set
 
-    result = invalg(shots, initial_value, loop_configuration, verbose=True, status_configuration=status_configuration, petsc='mkl_pardiso')
-
+    #result = invalg(shots, initial_value, loop_configuration, verbose=True, status_configuration=status_configuration, petsc='mkl_pardiso')
+    result = invalg(shots, initial_value, loop_configuration, verbose=True, status_configuration=status_configuration, petsc='mumps')
     print '...run time:  {0}s'.format(time.time()-tt)
 
     obj_vals = np.array([v for k,v in invalg.objective_history.items()])

--- a/pysit/modeling/frequency_modeling.py
+++ b/pysit/modeling/frequency_modeling.py
@@ -420,6 +420,7 @@ class FrequencyModeling(object):
 
         # if we are dealing with variable density, we need to collect the gradient operators, D1 and D2. (note: D2 is the negative adjoint of the leftmost gradient used in our heterogenous laplacian)
         if hasattr(m0, 'kappa') and hasattr(m0,'rho'):
+            print "WARNING: Ian's operators are still used here even though the solver has changed. Gradient may be incorrect. These routines need to be updated."
             deltas = [mesh.x.delta,mesh.z.delta]
             sh = mesh.shape(include_bc=True,as_grid=True)
             D1, D2 = build_heterogenous_matrices(sh,deltas)
@@ -906,6 +907,7 @@ class FrequencyModeling(object):
 
         rp=dict()
         rp['laplacian']=True
+        print "WARNING: Ian's operators are still used here even though the solver has changed. These tests need to be updated."
         Lap = build_heterogenous_matrices(sh,[mesh.x.delta,mesh.z.delta],model_2.reshape(-1,),rp=rp)
         # Storage for the field     
         u1hats = dict()

--- a/pysit/modeling/frequency_modeling.py
+++ b/pysit/modeling/frequency_modeling.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import
 
 import itertools
-from pysit.util.derivatives import build_derivative_matrix, build_permutation_matrix, build_heterogenous_laplacian, build_heterogenous_matrices
+from pysit.util.derivatives import build_derivative_matrix, build_permutation_matrix, build_heterogenous_matrices
 import sys
 import numpy as np
 from numpy.random import uniform
-
-from pysit.util.derivatives import build_derivative_matrix, build_permutation_matrix, build_heterogenous_laplacian, build_heterogenous_matrices
 
 __all__ = ['FrequencyModeling']
 

--- a/pysit/modeling/temporal_modeling.py
+++ b/pysit/modeling/temporal_modeling.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import numpy as np
-from pysit.util.derivatives import build_derivative_matrix, build_permutation_matrix, build_heterogenous_laplacian, build_heterogenous_matrices
+from pysit.util.derivatives import build_derivative_matrix, build_permutation_matrix, build_heterogenous_matrices
 from numpy.random import uniform
 
 __all__ = ['TemporalModeling']

--- a/pysit/modeling/temporal_modeling.py
+++ b/pysit/modeling/temporal_modeling.py
@@ -289,6 +289,7 @@ class TemporalModeling(object):
 
         # Variable-Density will call this, giving us matrices needed for the ic in terms of m2 (or rho)
         if hasattr(m0, 'kappa') and hasattr(m0,'rho'):
+            print "WARNING: Ian's operators are still used here even though the solver has changed. Gradient may be incorrect. These routines need to be updated."
             deltas = [mesh.x.delta,mesh.z.delta]
             sh = mesh.shape(include_bc=True,as_grid=True)
             D1,D2=build_heterogenous_matrices(sh,deltas)
@@ -730,6 +731,7 @@ class TemporalModeling(object):
         model_2=mesh.pad_array(model_2)
 
         #Lap = build_heterogenous_(sh,model_2,[mesh.x.delta,mesh.z.delta])
+        print "WARNING: Ian's operators are still used here even though the solver has changed. These tests need to be updated."
         rp=dict()
         rp['laplacian']=True
         Lap = build_heterogenous_matrices(sh,[mesh.x.delta,mesh.z.delta],model_2.reshape(-1,),rp=rp)

--- a/pysit/modeling/temporal_modeling.py
+++ b/pysit/modeling/temporal_modeling.py
@@ -54,7 +54,7 @@ class TemporalModeling(object):
     def _setup_forward_rhs(self, rhs_array, data):
         return self.solver.mesh.pad_array(data, out_array=rhs_array)
 
-    def forward_model(self, shot, m0, imaging_period, return_parameters=[]):
+    def forward_model(self, shot, m0, imaging_period=1, return_parameters=[]):
         """Applies the forward model to the model for the given solver.
 
         Parameters
@@ -219,7 +219,7 @@ class TemporalModeling(object):
 
         return rhs_array
 
-    def adjoint_model(self, shot, m0, operand_simdata, imaging_period, operand_dWaveOpAdj=None, operand_model=None, return_parameters=[], dWaveOp=None, wavefield=None):
+    def adjoint_model(self, shot, m0, operand_simdata, imaging_period=1, operand_dWaveOpAdj=None, operand_model=None, return_parameters=[], dWaveOp=None, wavefield=None):
         """Solves for the adjoint field.
 
         For constant density: m*q_tt - lap q = resid, where m = 1.0/c**2
@@ -1071,7 +1071,7 @@ def adjoint_test():
 
     #   Generate true wave speed
     #   (M = C^-2 - C0^-2)
-    C0, C = horizontal_reflector(m)
+    C, C0, m, d = horizontal_reflector(m)
 
     # Set up shots
     Nshots = 1
@@ -1123,7 +1123,7 @@ def adjoint_test():
     m1 = m0.perturbation()
     m1 += np.random.rand(*m1.data.shape)
 
-    fwdret = tools.forward_model(shot, m0, ['wavefield', 'dWaveOp', 'simdata'])
+    fwdret = tools.forward_model(shot, m0, return_parameters = ['wavefield', 'dWaveOp', 'simdata'])
     dWaveOp0 = fwdret['dWaveOp']
     inc_field = fwdret['wavefield']
     data = fwdret['simdata']
@@ -1153,6 +1153,8 @@ def adjoint_test():
         qhat += qs[k]*(np.exp(-1j*2.0*np.pi*10.0*t)*dt)
 
 if __name__ == '__main__':
+    print "Constant density solver adjoint test:"
+    adjoint_test()
     print "testing pertubation of rho:"
     adjoint_test_rho()
     print "testing pertubation of kappa:"

--- a/pysit/solvers/variable_density_acoustic/frequency/variable_density_acoustic_frequency_scalar_2D.py
+++ b/pysit/solvers/variable_density_acoustic/frequency/variable_density_acoustic_frequency_scalar_2D.py
@@ -6,7 +6,7 @@ from variable_density_acoustic_frequency_scalar_base import *
 
 from pysit.util import Bunch
 from pysit.util import PositiveEvenIntegers
-from pysit.util.derivatives import build_derivative_matrix, build_heterogenous_laplacian
+from pysit.util.derivatives import build_derivative_matrix, build_derivative_matrix_VDA
 from pysit.util.matrix_helpers import build_sigma, make_diag_mtx
 
 from pysit.util.solvers import inherit_dict
@@ -199,7 +199,11 @@ class VariableDensityAcousticFrequencyScalar_2D(VariableDensityAcousticFrequency
         # build heterogenous laplacian
         sh = self.mesh.shape(include_bc=True,as_grid=True)
         deltas = [self.mesh.x.delta,self.mesh.z.delta]
-        oc.L = build_heterogenous_laplacian(sh,rho**-1,deltas)
+        oc.L = build_derivative_matrix_VDA(self.mesh,
+                                           2,
+                                           self.spatial_accuracy_order,
+                                           alpha = rho**-1
+                                           )
 
         # oc.L is a heterogenous laplacian operator. It computes div(m2 grad), where m2 = 1/rho. 
         # Currently the creation of oc.L is slow. This is because we have implemented a cenetered heterogenous laplacian.

--- a/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
+++ b/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
@@ -8,7 +8,7 @@ from variable_density_acoustic_time_scalar_base import *
 
 from pysit.util import Bunch
 from pysit.util import PositiveEvenIntegers
-from pysit.util.derivatives import build_derivative_matrix, build_heterogenous_laplacian
+from pysit.util.derivatives import build_derivative_matrix, build_derivative_matrix_VDA, build_heterogenous_laplacian
 from pysit.util.matrix_helpers import build_sigma, make_diag_mtx
 
 from pysit.util.solvers import inherit_dict
@@ -77,9 +77,9 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
             # build the static components
             if not built:
                 # build homogeneous laplacian
-                oc.L_hom = build_derivative_matrix(self.mesh,
-                                                            2,
-                                                            self.spatial_accuracy_order)
+                ##oc.L_hom = build_derivative_matrix(self.mesh,
+                ##                                            2,
+                ##                                            self.spatial_accuracy_order)
                 
                 # build sigmax
                 sx = build_sigma(self.mesh, self.mesh.x)
@@ -105,38 +105,38 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
                 oc.minus_Dz = copy.deepcopy(oc.Dz)      #more storage, but less computations
                 oc.minus_Dz.data *= -1                                  
 
-                #Without modification, d_rho_inv_dx and d_rho_inv_dz will be nonzero around the respective
-                #outer PML boundaries because the differentiation coefficients don't add up to 1.0.
-                #A constant density would result in nonzero derivative values around the PML outer boundary
+                ## #Without modification, d_rho_inv_dx and d_rho_inv_dz will be nonzero around the respective
+                ## #outer PML boundaries because the differentiation coefficients don't add up to 1.0.
+                ## #A constant density would result in nonzero derivative values around the PML outer boundary
                 
-                #The approach I try here is to extend the density outwards by a few pixels in each direction.
-                #Then I can use a slightly larger differentiation operator associated with this extended mesh.
-                #Now the rows in the matrix that add up to non-zero are in the added padded pixels.
-                #Strip these and return the density derivatives within the original mesh.
+                ## #The approach I try here is to extend the density outwards by a few pixels in each direction.
+                ## #Then I can use a slightly larger differentiation operator associated with this extended mesh.
+                ## #Now the rows in the matrix that add up to non-zero are in the added padded pixels.
+                ## #Strip these and return the density derivatives within the original mesh.
                 
-                d = self.mesh.domain
-                self.n_pad = self.spatial_accuracy_order/2 + 1
-                dx = self.mesh.x.delta
-                dz = self.mesh.z.delta
-                nx = self.mesh.x.n
-                nz = self.mesh.z.n
+                ##d = self.mesh.domain
+                ##self.n_pad = self.spatial_accuracy_order/2 + 1
+                ##dx = self.mesh.x.delta
+                ##dz = self.mesh.z.delta
+                ##nx = self.mesh.x.n
+                ##nz = self.mesh.z.n
                 
-                extended_x_config = (d.x.lbound - self.n_pad*dx, d.x.rbound + self.n_pad*dx, copy.deepcopy(d.x.lbc), copy.deepcopy(d.x.rbc))
-                extended_z_config = (d.z.lbound - self.n_pad*dz, d.z.rbound + self.n_pad*dz, copy.deepcopy(d.z.lbc), copy.deepcopy(d.z.rbc))
+                ##extended_x_config = (d.x.lbound - self.n_pad*dx, d.x.rbound + self.n_pad*dx, copy.deepcopy(d.x.lbc), copy.deepcopy(d.x.rbc))
+                ##extended_z_config = (d.z.lbound - self.n_pad*dz, d.z.rbound + self.n_pad*dz, copy.deepcopy(d.z.lbc), copy.deepcopy(d.z.rbc))
                 
-                extended_domain = RectangularDomain(extended_x_config, extended_z_config)
+                ##extended_domain = RectangularDomain(extended_x_config, extended_z_config)
                 
-                self.extended_mesh = CartesianMesh(extended_domain, nx+2*self.n_pad, nz+2*self.n_pad)
+                ##self.extended_mesh = CartesianMesh(extended_domain, nx+2*self.n_pad, nz+2*self.n_pad)
                 
-                oc.Dx_modified_in_pml = build_derivative_matrix(self.extended_mesh,
-                                                                        1,
-                                                                        self.spatial_accuracy_order,
-                                                                        dimension='x') 
+                ##oc.Dx_modified_in_pml = build_derivative_matrix(self.extended_mesh,
+                ##                                                        1,
+                ##                                                        self.spatial_accuracy_order,
+                ##                                                        dimension='x') 
 
-                oc.Dz_modified_in_pml = build_derivative_matrix(self.extended_mesh,
-                                                                        1,
-                                                                        self.spatial_accuracy_order,
-                                                                        dimension='z')
+                ##oc.Dz_modified_in_pml = build_derivative_matrix(self.extended_mesh,
+                ##                                                        1,
+                ##                                                        self.spatial_accuracy_order,
+                ##                                                        dimension='z')
 
     
                 # build other useful things
@@ -156,51 +156,55 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
             rho = self.model_parameters.rho
             
             #temporarily pad rho so we can do the derivative around the boundary
-            sh = self.mesh.shape(include_bc = True, as_grid = True)
-            rho_2d = np.reshape(rho, sh, 'F')
-            rho_2d_padded = np.pad(rho_2d, [(self.n_pad,self.n_pad),(self.n_pad,self.n_pad)], mode='edge')
-            rho_padded = np.reshape(rho_2d_padded, ( (sh[0] + 2*self.n_pad) * (sh[1] + 2*self.n_pad), 1 ), 'F')
+            ##sh = self.mesh.shape(include_bc = True, as_grid = True)
+            ##rho_2d = np.reshape(rho, sh, 'F')
+            ##rho_2d_padded = np.pad(rho_2d, [(self.n_pad,self.n_pad),(self.n_pad,self.n_pad)], mode='edge')
+            ##rho_padded = np.reshape(rho_2d_padded, ( (sh[0] + 2*self.n_pad) * (sh[1] + 2*self.n_pad), 1 ), 'F')
     
             oc.m1 = make_diag_mtx((kappa**-1).reshape(-1,))
             oc.m2 = make_diag_mtx((rho**-1).reshape(-1,))
 
             #Take deriv on padded 
-            d_rho_padded_inv_dx = oc.Dx_modified_in_pml*(rho_padded**-1)
-            d_rho_padded_inv_dz = oc.Dz_modified_in_pml*(rho_padded**-1)
+            ##d_rho_padded_inv_dx = oc.Dx_modified_in_pml*(rho_padded**-1)
+            ##d_rho_padded_inv_dz = oc.Dz_modified_in_pml*(rho_padded**-1)
 
             #go to 2D so we can strip the padded values away
-            d_rho_inv_dx_padded_2d = np.reshape(d_rho_padded_inv_dx, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F')
-            d_rho_inv_dz_padded_2d = np.reshape(d_rho_padded_inv_dz, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F') 
+            ##d_rho_inv_dx_padded_2d = np.reshape(d_rho_padded_inv_dx, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F')
+            ##d_rho_inv_dz_padded_2d = np.reshape(d_rho_padded_inv_dz, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F') 
 
             #remove padding
-            d_rho_inv_dx_2d = d_rho_inv_dx_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]]
-            d_rho_inv_dz_2d = d_rho_inv_dz_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]] 
+            ##d_rho_inv_dx_2d = d_rho_inv_dx_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]]
+            ##d_rho_inv_dz_2d = d_rho_inv_dz_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]] 
 
             #back to 1D
-            d_rho_inv_dx = np.reshape(d_rho_inv_dx_2d, (sh[0] * sh[1], 1 ), 'F')
-            d_rho_inv_dz = np.reshape(d_rho_inv_dz_2d, (sh[0] * sh[1], 1 ), 'F')
+            ##d_rho_inv_dx = np.reshape(d_rho_inv_dx_2d, (sh[0] * sh[1], 1 ), 'F')
+            ##d_rho_inv_dz = np.reshape(d_rho_inv_dz_2d, (sh[0] * sh[1], 1 ), 'F')
 
-            d_rho_inv_dx_as_diag_mat = make_diag_mtx(d_rho_inv_dx.flatten())
-            d_rho_inv_dz_as_diag_mat = make_diag_mtx(d_rho_inv_dz.flatten())
+            ##d_rho_inv_dx_as_diag_mat = make_diag_mtx(d_rho_inv_dx.flatten())
+            ##d_rho_inv_dz_as_diag_mat = make_diag_mtx(d_rho_inv_dz.flatten())
             
-            #The next operator components will compute the deriv of 
-            #p(x) and multiply by the deriv of 1/rho in the same direction.
-            #Then these directions are summed, so we compute the 
-            #dot product between (grad(1/rho) and grad (p) at each pixel. 
-            #The sum implements (grad 1/rho) dot grad(p)
+            ## #The next operator components will compute the deriv of 
+            ## #p(x) and multiply by the deriv of 1/rho in the same direction.
+            ## #Then these directions are summed, so we compute the 
+            ## #dot product between (grad(1/rho) and grad (p) at each pixel. 
+            ## #The sum implements (grad 1/rho) dot grad(p)
             
-            d_rho_inv_dx_times_d_dx = d_rho_inv_dx_as_diag_mat * oc.Dx #mat-vec
-            d_rho_inv_dz_times_d_dz = d_rho_inv_dz_as_diag_mat * oc.Dz #mat-vec
+            ##d_rho_inv_dx_times_d_dx = d_rho_inv_dx_as_diag_mat * oc.Dx #mat-vec
+            ##d_rho_inv_dz_times_d_dz = d_rho_inv_dz_as_diag_mat * oc.Dz #mat-vec
             
             #oc.L applied to wavefield p: = (grad 1/rho) dot grad(p) + 1/rho*Laplacian(p)  
-            oc.L = (d_rho_inv_dx_times_d_dx + d_rho_inv_dz_times_d_dz) + oc.m2*oc.L_hom
+            ##oc.L = (d_rho_inv_dx_times_d_dx + d_rho_inv_dz_times_d_dz) + oc.m2*oc.L_hom
             
             # build heterogenous laplacian
             #sh = self.mesh.shape(include_bc=True,as_grid=True)
             #deltas = [self.mesh.x.delta,self.mesh.z.delta]
             #oc.L = build_heterogenous_laplacian(sh,rho**-1,deltas)
-    
-    
+            oc.L = build_derivative_matrix_VDA(self.mesh,
+                                               2,
+                                               self.spatial_accuracy_order,
+                                               alpha = rho**-1
+                                               )
+            
     
             # oc.L is a heterogenous laplacian operator. It computes div(m2 grad), where m2 = 1/rho. 
             # Currently the creation of oc.L is slow. This is because we have implemented a cenetered heterogenous laplacian.

--- a/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
+++ b/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
@@ -189,8 +189,8 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
             #dot product between (grad(1/rho) and grad (p) at each pixel. 
             #The sum implements (grad 1/rho) dot grad(p)
             
-            d_rho_inv_dx_times_d_dx = d_rho_inv_dx_as_diag_mat * oc.Dx
-            d_rho_inv_dz_times_d_dz = d_rho_inv_dz_as_diag_mat * oc.Dz
+            d_rho_inv_dx_times_d_dx = d_rho_inv_dx_as_diag_mat * oc.Dx #mat-vec
+            d_rho_inv_dz_times_d_dz = d_rho_inv_dz_as_diag_mat * oc.Dz #mat-vec
             
             #oc.L applied to wavefield p: = (grad 1/rho) dot grad(p) + 1/rho*Laplacian(p)  
             oc.L = (d_rho_inv_dx_times_d_dx + d_rho_inv_dz_times_d_dz) + oc.m2*oc.L_hom

--- a/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
+++ b/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
@@ -8,7 +8,7 @@ from variable_density_acoustic_time_scalar_base import *
 
 from pysit.util import Bunch
 from pysit.util import PositiveEvenIntegers
-from pysit.util.derivatives import build_derivative_matrix, build_derivative_matrix_VDA, build_heterogenous_laplacian
+from pysit.util.derivatives import build_derivative_matrix, build_derivative_matrix_VDA
 from pysit.util.matrix_helpers import build_sigma, make_diag_mtx
 
 from pysit.util.solvers import inherit_dict
@@ -128,7 +128,7 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
             
     
             # oc.L is a heterogenous laplacian operator. It computes div(m2 grad), where m2 = 1/rho. 
-            # Ian's implementation used the regular Dx operators in the PML even though the heterogeneous Laplacian is used in the physical domain.
+            # Ian's implementation used the regular Dx operators in the PML even though the heterogeneous Laplacian with staggered derivative operators is used in the physical domain.
             # I (Bram) did not change this or investigate if this causes some problems but am noting it here for completeness. 
             
             K = spsp.bmat([[oc.m1*oc.sigma_xz-oc.L, oc.minus_Dx*oc.m2, oc.minus_Dz*oc.m2 ],

--- a/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
+++ b/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
@@ -1,6 +1,8 @@
+import copy
 import numpy as np
 import scipy.sparse as spsp
 
+from pysit.core import CartesianMesh, RectangularDomain
 from pysit.solvers.wavefield_vector import *
 from variable_density_acoustic_time_scalar_base import *
 
@@ -63,83 +65,163 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
                            'precision': ['single', 'double']}
 
     def _rebuild_operators(self):
+    
+            VariableDensityAcousticTimeScalar_2D._rebuild_operators(self)
+    
+            dof = self.mesh.dof(include_bc=True)
+    
+            oc = self.operator_components
+    
+            built = oc.get('_numpy_components_built', False)
+    
+            # build the static components
+            if not built:
+                # build homogeneous laplacian
+                oc.L_hom = build_derivative_matrix(self.mesh,
+                                                            2,
+                                                            self.spatial_accuracy_order)
+                
+                # build sigmax
+                sx = build_sigma(self.mesh, self.mesh.x)
+                oc.sigmax = make_diag_mtx(sx)
+    
+                # build sigmaz
+                sz = build_sigma(self.mesh, self.mesh.z)
+                oc.sigmaz = make_diag_mtx(sz)
+    
+                # build Dx
+                oc.Dx = build_derivative_matrix(self.mesh,
+                                                        1,
+                                                        self.spatial_accuracy_order,
+                                                        dimension='x')
+                oc.minus_Dx = copy.deepcopy(oc.Dx)      #more storage, but less computations
+                oc.minus_Dx.data *= -1                  
+    
+                # build Dz
+                oc.Dz = build_derivative_matrix(self.mesh,
+                                                        1,
+                                                        self.spatial_accuracy_order,
+                                                        dimension='z')
+                oc.minus_Dz = copy.deepcopy(oc.Dz)      #more storage, but less computations
+                oc.minus_Dz.data *= -1                                  
 
-        VariableDensityAcousticTimeScalar_2D._rebuild_operators(self)
+                #Without modification, d_rho_inv_dx and d_rho_inv_dz will be nonzero around the respective
+                #outer PML boundaries because the differentiation coefficients don't add up to 1.0.
+                #A constant density would result in nonzero derivative values around the PML outer boundary
+                
+                #The approach I try here is to extend the density outwards by a few pixels in each direction.
+                #Then I can use a slightly larger differentiation operator associated with this extended mesh.
+                #Now the rows in the matrix that add up to non-zero are in the added padded pixels.
+                #Strip these and return the density derivatives within the original mesh.
+                
+                d = self.mesh.domain
+                self.n_pad = self.spatial_accuracy_order/2 + 1
+                dx = self.mesh.x.delta
+                dz = self.mesh.z.delta
+                nx = self.mesh.x.n
+                nz = self.mesh.z.n
+                
+                extended_x_config = (d.x.lbound - self.n_pad*dx, d.x.rbound + self.n_pad*dx, copy.deepcopy(d.x.lbc), copy.deepcopy(d.x.rbc))
+                extended_z_config = (d.z.lbound - self.n_pad*dz, d.z.rbound + self.n_pad*dz, copy.deepcopy(d.z.lbc), copy.deepcopy(d.z.rbc))
+                
+                extended_domain = RectangularDomain(extended_x_config, extended_z_config)
+                
+                self.extended_mesh = CartesianMesh(extended_domain, nx+2*self.n_pad, nz+2*self.n_pad)
+                
+                oc.Dx_modified_in_pml = build_derivative_matrix(self.extended_mesh,
+                                                                        1,
+                                                                        self.spatial_accuracy_order,
+                                                                        dimension='x') 
 
-        dof = self.mesh.dof(include_bc=True)
+                oc.Dz_modified_in_pml = build_derivative_matrix(self.extended_mesh,
+                                                                        1,
+                                                                        self.spatial_accuracy_order,
+                                                                        dimension='z')
 
-        oc = self.operator_components
+    
+                # build other useful things
+                oc.I = spsp.eye(dof, dof)
+                oc.empty = spsp.csr_matrix((dof, dof))
+    
+                # useful intermediates
+                oc.sigma_xz  = make_diag_mtx(sx*sz)
+                oc.sigma_xPz = oc.sigmax + oc.sigmaz
+    
+                oc.minus_sigma_zMx_Dx = make_diag_mtx((sz-sx))*oc.minus_Dx
+                oc.minus_sigma_xMz_Dz = make_diag_mtx((sx-sz))*oc.minus_Dz
+    
+                oc._numpy_components_built = True
 
-        built = oc.get('_numpy_components_built', False)
+            kappa = self.model_parameters.kappa
+            rho = self.model_parameters.rho
+            
+            #temporarily pad rho so we can do the derivative around the boundary
+            sh = self.mesh.shape(include_bc = True, as_grid = True)
+            rho_2d = np.reshape(rho, sh, 'F')
+            rho_2d_padded = np.pad(rho_2d, [(self.n_pad,self.n_pad),(self.n_pad,self.n_pad)], mode='edge')
+            rho_padded = np.reshape(rho_2d_padded, ( (sh[0] + 2*self.n_pad) * (sh[1] + 2*self.n_pad), 1 ), 'F')
+    
+            oc.m1 = make_diag_mtx((kappa**-1).reshape(-1,))
+            oc.m2 = make_diag_mtx((rho**-1).reshape(-1,))
 
-        # build the static components
-        if not built:
-            # build sigmax
-            sx = build_sigma(self.mesh, self.mesh.x)
-            oc.sigmax = make_diag_mtx(sx)
+            #Take deriv on padded 
+            d_rho_padded_inv_dx = oc.Dx_modified_in_pml*(rho_padded**-1)
+            d_rho_padded_inv_dz = oc.Dz_modified_in_pml*(rho_padded**-1)
 
-            # build sigmaz
-            sz = build_sigma(self.mesh, self.mesh.z)
-            oc.sigmaz = make_diag_mtx(sz)
+            #go to 2D so we can strip the padded values away
+            d_rho_inv_dx_padded_2d = np.reshape(d_rho_padded_inv_dx, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F')
+            d_rho_inv_dz_padded_2d = np.reshape(d_rho_padded_inv_dz, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F') 
 
-            # build Dx
-            oc.minus_Dx = build_derivative_matrix(self.mesh,
-                                                  1,
-                                                  self.spatial_accuracy_order,
-                                                  dimension='x')
-            oc.minus_Dx.data *= -1
+            #remove padding
+            d_rho_inv_dx_2d = d_rho_inv_dx_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]]
+            d_rho_inv_dz_2d = d_rho_inv_dz_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]] 
 
-            # build Dz
-            oc.minus_Dz = build_derivative_matrix(self.mesh,
-                                                  1,
-                                                  self.spatial_accuracy_order,
-                                                  dimension='z')
-            oc.minus_Dz.data *= -1
+            #back to 1D
+            d_rho_inv_dx = np.reshape(d_rho_inv_dx_2d, (sh[0] * sh[1], 1 ), 'F')
+            d_rho_inv_dz = np.reshape(d_rho_inv_dz_2d, (sh[0] * sh[1], 1 ), 'F')
 
-            # build other useful things
-            oc.I = spsp.eye(dof, dof)
-            oc.empty = spsp.csr_matrix((dof, dof))
-
-            # useful intermediates
-            oc.sigma_xz  = make_diag_mtx(sx*sz)
-            oc.sigma_xPz = oc.sigmax + oc.sigmaz
-
-            oc.minus_sigma_zMx_Dx = make_diag_mtx((sz-sx))*oc.minus_Dx
-            oc.minus_sigma_xMz_Dz = make_diag_mtx((sx-sz))*oc.minus_Dz
-
-            oc._numpy_components_built = True
-
-        kappa = self.model_parameters.kappa
-        rho = self.model_parameters.rho
-
-        oc.m1 = make_diag_mtx((kappa**-1).reshape(-1,))
-        oc.m2 = make_diag_mtx((rho**-1).reshape(-1,))
-        
-        # build heterogenous laplacian
-        sh = self.mesh.shape(include_bc=True,as_grid=True)
-        deltas = [self.mesh.x.delta,self.mesh.z.delta]
-        oc.L = build_heterogenous_laplacian(sh,rho**-1,deltas)
-
-        # oc.L is a heterogenous laplacian operator. It computes div(m2 grad), where m2 = 1/rho. 
-        # Currently the creation of oc.L is slow. This is because we have implemented a cenetered heterogenous laplacian.
-        # To speed up computation, we could compute a div(m2 grad) operator that is not centered by simply multiplying
-        # a divergence operator by oc.m2 by a gradient operator.
-
-        K = spsp.bmat([[oc.m1*oc.sigma_xz-oc.L, oc.minus_Dx*oc.m2, oc.minus_Dz*oc.m2 ],
-                       [oc.minus_sigma_zMx_Dx, oc.sigmax,   oc.empty    ],
-                       [oc.minus_sigma_xMz_Dz, oc.empty,    oc.sigmaz   ]])
-
-        C = spsp.bmat([[oc.m1*oc.sigma_xPz, oc.empty, oc.empty],
-                       [oc.empty,          oc.I,     oc.empty],
-                       [oc.empty,          oc.empty, oc.I    ]]) / self.dt
-
-        M = spsp.bmat([[    oc.m1, oc.empty, oc.empty],
-                       [oc.empty, oc.empty, oc.empty],
-                       [oc.empty, oc.empty, oc.empty]]) / self.dt**2
-
-        Stilde_inv = M+C
-        Stilde_inv.data = 1./Stilde_inv.data
-
-        self.A_k   = Stilde_inv*(2*M - K + C)
-        self.A_km1 = -1*Stilde_inv*(M)
-        self.A_f   = Stilde_inv
+            d_rho_inv_dx_as_diag_mat = make_diag_mtx(d_rho_inv_dx.flatten())
+            d_rho_inv_dz_as_diag_mat = make_diag_mtx(d_rho_inv_dz.flatten())
+            
+            #The next operator components will compute the deriv of 
+            #p(x) and multiply by the deriv of 1/rho in the same direction.
+            #Then these directions are summed, so we compute the 
+            #dot product between (grad(1/rho) and grad (p) at each pixel. 
+            #The sum implements (grad 1/rho) dot grad(p)
+            
+            d_rho_inv_dx_times_d_dx = d_rho_inv_dx_as_diag_mat * oc.Dx
+            d_rho_inv_dz_times_d_dz = d_rho_inv_dz_as_diag_mat * oc.Dz
+            
+            #oc.L applied to wavefield p: = (grad 1/rho) dot grad(p) + 1/rho*Laplacian(p)  
+            oc.L = (d_rho_inv_dx_times_d_dx + d_rho_inv_dz_times_d_dz) + oc.m2*oc.L_hom
+            
+            # build heterogenous laplacian
+            #sh = self.mesh.shape(include_bc=True,as_grid=True)
+            #deltas = [self.mesh.x.delta,self.mesh.z.delta]
+            #oc.L = build_heterogenous_laplacian(sh,rho**-1,deltas)
+    
+    
+    
+            # oc.L is a heterogenous laplacian operator. It computes div(m2 grad), where m2 = 1/rho. 
+            # Currently the creation of oc.L is slow. This is because we have implemented a cenetered heterogenous laplacian.
+            # To speed up computation, we could compute a div(m2 grad) operator that is not centered by simply multiplying
+            # a divergence operator by oc.m2 by a gradient operator.
+    
+            K = spsp.bmat([[oc.m1*oc.sigma_xz-oc.L, oc.minus_Dx*oc.m2, oc.minus_Dz*oc.m2 ],
+                           [oc.minus_sigma_zMx_Dx, oc.sigmax,   oc.empty    ],
+                           [oc.minus_sigma_xMz_Dz, oc.empty,    oc.sigmaz   ]])
+    
+            C = spsp.bmat([[oc.m1*oc.sigma_xPz, oc.empty, oc.empty],
+                           [oc.empty,          oc.I,     oc.empty],
+                           [oc.empty,          oc.empty, oc.I    ]]) / self.dt
+    
+            M = spsp.bmat([[    oc.m1, oc.empty, oc.empty],
+                           [oc.empty, oc.empty, oc.empty],
+                           [oc.empty, oc.empty, oc.empty]]) / self.dt**2
+    
+            Stilde_inv = M+C
+            Stilde_inv.data = 1./Stilde_inv.data
+    
+            self.A_k   = Stilde_inv*(2*M - K + C)
+            self.A_km1 = -1*Stilde_inv*(M)
+            self.A_f   = Stilde_inv

--- a/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
+++ b/pysit/solvers/variable_density_acoustic/time/scalar/variable_density_acoustic_time_scalar_2D.py
@@ -76,11 +76,6 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
     
             # build the static components
             if not built:
-                # build homogeneous laplacian
-                ##oc.L_hom = build_derivative_matrix(self.mesh,
-                ##                                            2,
-                ##                                            self.spatial_accuracy_order)
-                
                 # build sigmax
                 sx = build_sigma(self.mesh, self.mesh.x)
                 oc.sigmax = make_diag_mtx(sx)
@@ -105,39 +100,6 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
                 oc.minus_Dz = copy.deepcopy(oc.Dz)      #more storage, but less computations
                 oc.minus_Dz.data *= -1                                  
 
-                ## #Without modification, d_rho_inv_dx and d_rho_inv_dz will be nonzero around the respective
-                ## #outer PML boundaries because the differentiation coefficients don't add up to 1.0.
-                ## #A constant density would result in nonzero derivative values around the PML outer boundary
-                
-                ## #The approach I try here is to extend the density outwards by a few pixels in each direction.
-                ## #Then I can use a slightly larger differentiation operator associated with this extended mesh.
-                ## #Now the rows in the matrix that add up to non-zero are in the added padded pixels.
-                ## #Strip these and return the density derivatives within the original mesh.
-                
-                ##d = self.mesh.domain
-                ##self.n_pad = self.spatial_accuracy_order/2 + 1
-                ##dx = self.mesh.x.delta
-                ##dz = self.mesh.z.delta
-                ##nx = self.mesh.x.n
-                ##nz = self.mesh.z.n
-                
-                ##extended_x_config = (d.x.lbound - self.n_pad*dx, d.x.rbound + self.n_pad*dx, copy.deepcopy(d.x.lbc), copy.deepcopy(d.x.rbc))
-                ##extended_z_config = (d.z.lbound - self.n_pad*dz, d.z.rbound + self.n_pad*dz, copy.deepcopy(d.z.lbc), copy.deepcopy(d.z.rbc))
-                
-                ##extended_domain = RectangularDomain(extended_x_config, extended_z_config)
-                
-                ##self.extended_mesh = CartesianMesh(extended_domain, nx+2*self.n_pad, nz+2*self.n_pad)
-                
-                ##oc.Dx_modified_in_pml = build_derivative_matrix(self.extended_mesh,
-                ##                                                        1,
-                ##                                                        self.spatial_accuracy_order,
-                ##                                                        dimension='x') 
-
-                ##oc.Dz_modified_in_pml = build_derivative_matrix(self.extended_mesh,
-                ##                                                        1,
-                ##                                                        self.spatial_accuracy_order,
-                ##                                                        dimension='z')
-
     
                 # build other useful things
                 oc.I = spsp.eye(dof, dof)
@@ -154,51 +116,10 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
 
             kappa = self.model_parameters.kappa
             rho = self.model_parameters.rho
-            
-            #temporarily pad rho so we can do the derivative around the boundary
-            ##sh = self.mesh.shape(include_bc = True, as_grid = True)
-            ##rho_2d = np.reshape(rho, sh, 'F')
-            ##rho_2d_padded = np.pad(rho_2d, [(self.n_pad,self.n_pad),(self.n_pad,self.n_pad)], mode='edge')
-            ##rho_padded = np.reshape(rho_2d_padded, ( (sh[0] + 2*self.n_pad) * (sh[1] + 2*self.n_pad), 1 ), 'F')
     
             oc.m1 = make_diag_mtx((kappa**-1).reshape(-1,))
             oc.m2 = make_diag_mtx((rho**-1).reshape(-1,))
 
-            #Take deriv on padded 
-            ##d_rho_padded_inv_dx = oc.Dx_modified_in_pml*(rho_padded**-1)
-            ##d_rho_padded_inv_dz = oc.Dz_modified_in_pml*(rho_padded**-1)
-
-            #go to 2D so we can strip the padded values away
-            ##d_rho_inv_dx_padded_2d = np.reshape(d_rho_padded_inv_dx, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F')
-            ##d_rho_inv_dz_padded_2d = np.reshape(d_rho_padded_inv_dz, (sh[0]+2*self.n_pad, sh[1]+2*self.n_pad), 'F') 
-
-            #remove padding
-            ##d_rho_inv_dx_2d = d_rho_inv_dx_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]]
-            ##d_rho_inv_dz_2d = d_rho_inv_dz_padded_2d[self.n_pad:self.n_pad + sh[0],self.n_pad:self.n_pad + sh[1]] 
-
-            #back to 1D
-            ##d_rho_inv_dx = np.reshape(d_rho_inv_dx_2d, (sh[0] * sh[1], 1 ), 'F')
-            ##d_rho_inv_dz = np.reshape(d_rho_inv_dz_2d, (sh[0] * sh[1], 1 ), 'F')
-
-            ##d_rho_inv_dx_as_diag_mat = make_diag_mtx(d_rho_inv_dx.flatten())
-            ##d_rho_inv_dz_as_diag_mat = make_diag_mtx(d_rho_inv_dz.flatten())
-            
-            ## #The next operator components will compute the deriv of 
-            ## #p(x) and multiply by the deriv of 1/rho in the same direction.
-            ## #Then these directions are summed, so we compute the 
-            ## #dot product between (grad(1/rho) and grad (p) at each pixel. 
-            ## #The sum implements (grad 1/rho) dot grad(p)
-            
-            ##d_rho_inv_dx_times_d_dx = d_rho_inv_dx_as_diag_mat * oc.Dx #mat-vec
-            ##d_rho_inv_dz_times_d_dz = d_rho_inv_dz_as_diag_mat * oc.Dz #mat-vec
-            
-            #oc.L applied to wavefield p: = (grad 1/rho) dot grad(p) + 1/rho*Laplacian(p)  
-            ##oc.L = (d_rho_inv_dx_times_d_dx + d_rho_inv_dz_times_d_dz) + oc.m2*oc.L_hom
-            
-            # build heterogenous laplacian
-            #sh = self.mesh.shape(include_bc=True,as_grid=True)
-            #deltas = [self.mesh.x.delta,self.mesh.z.delta]
-            #oc.L = build_heterogenous_laplacian(sh,rho**-1,deltas)
             oc.L = build_derivative_matrix_VDA(self.mesh,
                                                2,
                                                self.spatial_accuracy_order,
@@ -207,10 +128,9 @@ class VariableDensityAcousticTimeScalar_2D_numpy(VariableDensityAcousticTimeScal
             
     
             # oc.L is a heterogenous laplacian operator. It computes div(m2 grad), where m2 = 1/rho. 
-            # Currently the creation of oc.L is slow. This is because we have implemented a cenetered heterogenous laplacian.
-            # To speed up computation, we could compute a div(m2 grad) operator that is not centered by simply multiplying
-            # a divergence operator by oc.m2 by a gradient operator.
-    
+            # Ian's implementation used the regular Dx operators in the PML even though the heterogeneous Laplacian is used in the physical domain.
+            # I (Bram) did not change this or investigate if this causes some problems but am noting it here for completeness. 
+            
             K = spsp.bmat([[oc.m1*oc.sigma_xz-oc.L, oc.minus_Dx*oc.m2, oc.minus_Dz*oc.m2 ],
                            [oc.minus_sigma_zMx_Dx, oc.sigmax,   oc.empty    ],
                            [oc.minus_sigma_xMz_Dz, oc.empty,    oc.sigmaz   ]])

--- a/pysit/tests/variable_density_solver_verification.py
+++ b/pysit/tests/variable_density_solver_verification.py
@@ -15,7 +15,6 @@
 
 from pysit import *
 from pysit_extensions.convenient_plot_functions.plot_functions import *
-from pysit.util.derivatives import build_heterogenous_laplacian
 import copy
 import numpy as np
 import sys

--- a/pysit/tests/variable_density_solver_verification.py
+++ b/pysit/tests/variable_density_solver_verification.py
@@ -1,0 +1,253 @@
+#1: I will show that for second order accuracy on a homogeneous model the CDA and VDA solver are exactly the same on a constant density medium
+
+#2: In this example I will show that the Laplacian of the variable density acoustics (VDA) solver is self-adjoint 
+#With the exception of the boundary nodes, which is also the case in the CDA solver.
+
+#3: For higher spatial accuracy orders the variable density solver on a constant density medium is more expensive.
+#It has almost twice as many bands in the laplacian as the CDA solver because the heterogeneous Laplacian
+#is implemented as div*((1/rho)grad) = -D^T((1/rho) *D). This process will create extra bands at higher orders of spatial accuracy.
+#This is the price we pay for a self-adjoint Laplacian in VDA
+
+#4: Simple demonstration. Uniform velocity, but density gradient. We observe reflection
+
+#5: Laplacian does not deviate from symmetry at the pixels centered around the density jump (i.e. pixels 50, 50+91, 50+182, 50+273, ...)
+
+
+from pysit import *
+from pysit_extensions.convenient_plot_functions.plot_functions import *
+from pysit.util.derivatives import build_heterogenous_laplacian
+import copy
+import numpy as np
+import sys
+import time
+import matplotlib.pyplot as plt
+import scipy.io as spio
+
+
+
+#   Define Domain
+dx = 12.5 
+dz = 12.5
+
+nx = 51 
+nz = 51
+
+x_min = 0.0
+x_max = (nx-1)*dx
+
+z_min = 0.0
+z_max = (nz-1)*dz
+
+pmlx = PML(20*dx, 50)
+pmlz = PML(20*dz, 50)
+
+x_config = (x_min, x_max, pmlx, pmlx)
+z_config = (z_min, z_max, pmlz, pmlz)
+
+d = RectangularDomain(x_config, z_config)
+
+m = CartesianMesh(d, nx, nz)
+
+#Define velocity and density
+background_vel = 1500.0
+C_2d = background_vel*np.ones((nz,nx)) #UNIFORM
+rho_2d = 1.0*np.ones((nz,nx))          #UNIFORM. Using 1.0 so results VDA solver should be the same as CDA solver
+
+kappa_2d = rho_2d*C_2d**2 # vp**2 = kappa/rho for acoustic medium. Kappa = lamba + 2\3 * mu = lambda when mu = 0 in acoustic medium  
+
+#create input arrays
+kappa = np.reshape(kappa_2d, (nx*nz,1),'F')
+rho   = np.reshape(rho_2d, (nx*nz,1),'F')
+C     = np.reshape(C_2d, (nx*nz,1),'F')
+
+#define model parameters
+model_param_cda = {'C': C}
+model_param_vda = {'kappa': kappa, 'rho': rho}
+
+# Set up shot
+peakfreq = 6.0
+depth_source_receiver = 12.5
+
+x_pos_source = 100.0 
+z_pos_source = depth_source_receiver
+
+x_pos_receivers = np.linspace(x_min, x_max, nx)
+z_pos_receivers = depth_source_receiver #I guess it will always record 0.0 because that is what this Dirichlet boundary is 
+
+shots_time_cda = []
+source_approx = 'delta'
+receiver_approx = 'delta'
+# Define source location and type
+source = PointSource(m, (x_pos_source, z_pos_source), RickerWavelet(peakfreq), approximation = source_approx)
+receivers = ReceiverSet(m, [PointReceiver(m, (x, z_pos_receivers), approximation = receiver_approx) for x in x_pos_receivers])
+shot = Shot(source, receivers)
+
+#Both start without any recorded data
+shots_time_cda.append(shot)
+shots_time_vda = copy.deepcopy(shots_time_cda)
+
+# Define and configure the wave solver
+trange = (0.0,2.0)
+
+accuracy_order = 2
+
+solver_time_cda = ConstantDensityAcousticWave(m,
+                                              spatial_accuracy_order=accuracy_order,
+                                              trange=trange,
+                                              kernel_implementation = 'numpy',
+                                              )
+
+solver_time_vda = VariableDensityAcousticWave(m,
+                                              spatial_accuracy_order=accuracy_order,
+                                              trange=trange,
+                                              kernel_implementation = 'numpy',
+                                              )
+
+# Generate synthetic Seismic data
+base_model_cda = solver_time_cda.ModelParameters(m,model_param_cda)
+base_model_vda = solver_time_vda.ModelParameters(m,model_param_vda)
+
+sys.stdout.write('Generating CDA solver data uniform model... \n')
+generate_seismic_data(shots_time_cda, solver_time_cda, base_model_cda)
+sys.stdout.write('Generating VDA solver data uniform model... \n')
+generate_seismic_data(shots_time_vda, solver_time_vda, base_model_vda)
+
+shotgather_time_cda = shots_time_cda[0].receivers.data
+shotgather_time_vda = shots_time_vda[0].receivers.data
+
+#divide by max: scalar difference due to density
+#shotgather_time_vda = shotgather_time_vda * (shotgather_time_cda.max()/shotgather_time_vda.max())
+rel_dif_time = np.linalg.norm(shotgather_time_vda - shotgather_time_cda)/np.linalg.norm(shotgather_time_vda)
+print "1: Relative difference in CDA and VDA solver on uniform grid and 2nd order in space: " + str(rel_dif_time) 
+print "Exactly the same for second order accuracy."
+
+L_cda = solver_time_cda.operator_components.L
+L_vda = solver_time_vda.operator_components.L
+
+#Laplacians are not exactly self adjoint because of boundary conditions. 
+CDA_deviation_self_adjoint = L_cda-L_cda.T
+VDA_deviation_self_adjoint = L_vda-L_vda.T 
+
+#remove some tiny deviations due to rounding errors
+eps = 1e-14
+
+#Remove elements between -eps and +eps
+elements_within_plus_min_eps = np.logical_and(CDA_deviation_self_adjoint.data<=eps, CDA_deviation_self_adjoint.data>=-eps)
+elements_not_within_plus_min_eps = np.logical_not(elements_within_plus_min_eps)
+CDA_deviation_self_adjoint.data *= elements_not_within_plus_min_eps 
+CDA_deviation_self_adjoint.eliminate_zeros()
+
+#Remove elements between -eps and +eps
+elements_within_plus_min_eps = np.logical_and(VDA_deviation_self_adjoint.data<=eps, VDA_deviation_self_adjoint.data>=-eps)
+elements_not_within_plus_min_eps = np.logical_not(elements_within_plus_min_eps)
+VDA_deviation_self_adjoint.data *= elements_not_within_plus_min_eps 
+VDA_deviation_self_adjoint.eliminate_zeros()
+
+
+print "2: Displaying entries with deviation from self adjoint larger than %e \n"%eps
+plt.figure(1); plt.spy(CDA_deviation_self_adjoint, markersize=3); plt.title('CDA entries deviating from self-adjoint')
+plt.figure(2); plt.spy(VDA_deviation_self_adjoint, markersize=3); plt.title('VDA entries deviating from self-adjoint')
+
+###############################################################
+############### NOW REPEAT FOR 8-TH ORDER ACCURACY ############
+###############################################################
+
+accuracy_order = 8
+
+solver_time_cda = ConstantDensityAcousticWave(m,
+                                              spatial_accuracy_order=accuracy_order,
+                                              trange=trange,
+                                              kernel_implementation = 'numpy',
+                                              )
+
+solver_time_vda = VariableDensityAcousticWave(m,
+                                              spatial_accuracy_order=accuracy_order,
+                                              trange=trange,
+                                              kernel_implementation = 'numpy',
+                                              )
+
+# Generate synthetic Seismic data
+base_model_cda = solver_time_cda.ModelParameters(m,model_param_cda)
+base_model_vda = solver_time_vda.ModelParameters(m,model_param_vda)
+
+sys.stdout.write('Generating CDA solver data uniform model... \n')
+generate_seismic_data(shots_time_cda, solver_time_cda, base_model_cda)
+sys.stdout.write('Generating VDA solver data uniform model... \n')
+generate_seismic_data(shots_time_vda, solver_time_vda, base_model_vda)
+
+shotgather_time_cda = shots_time_cda[0].receivers.data
+shotgather_time_vda = shots_time_vda[0].receivers.data
+
+rel_dif_time = np.linalg.norm(shotgather_time_vda - shotgather_time_cda)/np.linalg.norm(shotgather_time_vda)
+print "3: Relative difference in CDA and VDA solver on uniform grid and 8th order in space: " + str(rel_dif_time)
+print "Slightly different because VDA solver has more bands. But difference is tiny \n"
+
+#######################################################################
+############### NOW LOOK AT A CASE WITH A DENSITY CONTRAST ############
+############### still a PML which is too thin so some      ############ 
+############### artificial reflections.                    ############
+#######################################################################
+
+#Define velocity and density
+background_vel = 1500.0
+C_2d = background_vel*np.ones((nz,nx)) #UNIFORM
+rho_2d = 1000.0*np.ones((nz,nx))       
+rho_2d[30:,:] = 5000.0                 #INTRODUCE DENSITY JUMP AT DEPTH PIXEL 30 (50 IN PML PADDED MODEL, 20 PML NODES)
+
+kappa_2d = rho_2d*C_2d**2 # vp**2 = kappa/rho for acoustic medium. Kappa = lamba + 2\3 * mu = lambda when mu = 0 in acoustic medium  
+
+kappa = np.reshape(kappa_2d, (nx*nz,1),'F')
+rho   = np.reshape(rho_2d, (nx*nz,1),'F')
+C     = np.reshape(C_2d, (nx*nz,1),'F')
+
+model_param_cda = {'C': C}
+model_param_vda = {'kappa': kappa, 'rho': rho}
+
+# Set up shot
+shots_time_vda_bump = []
+source_approx = 'delta'
+receiver_approx = 'delta'
+# Define source location and type
+source = PointSource(m, (x_pos_source, z_pos_source), RickerWavelet(peakfreq), approximation = source_approx)
+receivers = ReceiverSet(m, [PointReceiver(m, (x, z_pos_receivers), approximation = receiver_approx) for x in x_pos_receivers])
+shot = Shot(source, receivers)
+shots_time_vda_bump.append(shot)
+
+# Define and configure the wave solver
+trange = (0.0,2.0)
+solver_time_vda_bump = VariableDensityAcousticWave(m,
+                                              spatial_accuracy_order=accuracy_order,
+                                              trange=trange,
+                                              kernel_implementation = 'numpy',
+                                              )
+
+# Generate synthetic Seismic data
+wavefields = []
+base_model_vda_bump = solver_time_vda_bump.ModelParameters(m,model_param_vda)
+generate_seismic_data(shots_time_vda_bump, solver_time_vda_bump, base_model_vda_bump, wavefields=wavefields)
+
+print "4: Plotting trace, constant velocity but density bump introduces reflection as expected"
+
+shotgather_time_vda_bump = shots_time_vda_bump[0].receivers.data
+plt.figure(4)
+plt.plot(shotgather_time_vda_bump[:,10])
+
+
+#Now that there is a density gradient, differences from self-adjoint could be introduced at the pixels surrounding the jump
+#Here in this Laplacian corresponding to the padded 91*91 model  
+
+L_vda_dense_bump = solver_time_vda_bump.operator_components.L
+VDA_bump_deviation_self_adjoint = L_vda_dense_bump - L_vda_dense_bump.T
+
+#Remove elements between -eps and +eps
+elements_within_plus_min_eps = np.logical_and(VDA_bump_deviation_self_adjoint.data<=eps, VDA_bump_deviation_self_adjoint.data>=-eps)
+elements_not_within_plus_min_eps = np.logical_not(elements_within_plus_min_eps)
+VDA_bump_deviation_self_adjoint.data *= elements_not_within_plus_min_eps 
+VDA_bump_deviation_self_adjoint.eliminate_zeros()
+
+print "5: Displaying entries with deviation from self adjoint larger than for density jump model %e \n"%eps
+plt.figure(5); plt.spy(VDA_bump_deviation_self_adjoint, markersize=3); plt.title('VDA entries deviating from self-adjoint dens bump model')
+plt.show()
+
+print "6: Plotting wavefield, constant velocity but density bump introduces reflection as expected"  
+vis.animate(wavefields, m, display_rate = 3)

--- a/pysit/util/derivatives/derivatives.py
+++ b/pysit/util/derivatives/derivatives.py
@@ -229,13 +229,27 @@ def build_permutation_matrix(nz,nx):
     # This creates a permutation matrix which transforms a column vector of nx
     # "component" columns of size nz, to the corresponding column vector of nz
     # "component" columns of size nx.
-    P=np.zeros((nz*nx,nz*nx))
-    v=np.zeros(nz*nx)
-    for i in xrange(nz):
-        for j in xrange(nx):
-            P[nx*i+j][:]=v
-            P[nx*i+j][i+j*nz]=1
-    return spsp.csr_matrix(P)
+    
+    def generate_matrix(nz, nx): #local function
+        P = spsp.lil_matrix((nz*nx,nz*nx)) 
+        for i in xrange(nz): #Looping is not efficient, but we only need to do it once as setup
+            for j in xrange(nx):
+                P[nx*i+j,i+j*nz]=1
+    
+        return P.tocsr()
+    
+    #Start body of code for 'build_permutation_matrix'
+    try: #See if there are already stored results from previous calls to this function
+        current_storage_dict = build_permutation_matrix.storage_dict
+    except: #If not, initialize
+        current_storage_dict = dict()
+        build_permutation_matrix.storage_dict = current_storage_dict
+    
+    if (nz,nx) not in current_storage_dict.keys(): #Have not precomputed this!
+        mat = generate_matrix(nz,nx)
+        current_storage_dict[nz,nx] = mat
+ 
+    return current_storage_dict[nz,nx]
 
 def build_offcentered_alpha(sh,alpha):
     # This computes the midpoints of alpha which will be used in the heterogenous laplacian

--- a/pysit/util/derivatives/fdweight.py
+++ b/pysit/util/derivatives/fdweight.py
@@ -4,7 +4,7 @@ import math
 
 import numpy as np
 
-__all__ = ['finite_difference_coefficients', 'centered_difference', 'shifted_difference']
+__all__ = ['finite_difference_coefficients', 'centered_difference', 'shifted_difference', 'staggered_difference']
 
 def centered_difference(deriv, order):
     if order%2:
@@ -12,6 +12,19 @@ def centered_difference(deriv, order):
     npoints = deriv + order + deriv%2 - 1
     center_idx = math.floor(npoints/2)
     return finite_difference_coefficients(center_idx, np.arange(npoints),deriv)
+
+def staggered_difference(deriv, order):
+    if deriv != 1:
+        raise ValueError('Only tested for first derivative. Probably extends like center_difference though. Not yet implemented.')
+
+    if order%2:
+        raise ValueError('Untested when order not even.')
+    
+    #Using Fornberg paper "CALCULATION OF WEIGHTS IN FINITE DIFFERENCE FORMULAS. Similar to case 2 in table 3
+    
+    npoints = order
+    center_idx = 0
+    return finite_difference_coefficients(center_idx, np.arange(npoints)-(npoints/2.)+0.5,deriv)
 
 def shifted_difference(deriv, order, shift):
     npoints = deriv+order

--- a/pysit/util/image_processing.py
+++ b/pysit/util/image_processing.py
@@ -79,7 +79,7 @@ def blur_image(im, sigma=None, freq=None, mesh_deltas=None, n_sigma=1.0):
         sigma = 1./freq
 
     # determine the size, in pixels, of the kernel
-    kernel_size_pixel = np.ceil(n_sigma*sigma / mesh_deltas)
+    kernel_size_pixel = (np.ceil(n_sigma*sigma / mesh_deltas)).astype('int32')
 
     kernel = gaussian_kernel(kernel_size_pixel, sigma, mesh_deltas)
 


### PR DESCRIPTION
Hi

The old variable density acoustics (VDA) implementation (i.e. current one in master branch) uses a hardcoded self-adjoint 2nd order accurate heterogeneous Laplacian. When during the construction of the solver a different spatial accuracy order is requested, most of the elements in the composite matrix are higher order accurate, but the heterogeneous Laplacian is still second order accurate. This leads to some massive dispersion problems. In addition, the construction of this hardcoded 2nd order accurate heterogeneous Laplacian is very slow. Constructing the matrices takes more time than doing the actual solve in some of the examples i was working on.

**What I did:**
-I wrote code for the heterogeneous Laplacian at arbitrary spatial accuracy 
-Integrated the Laplacian into the time and frequency 2D forward model
-I significantly improved the speed of the Laplacian generation. In my experience, this is no longer the step that defines the computational time of doing a forward model.
-I added a test script demonstrating the new variable density solver and doing some small comparisons in the Laplacian 
-For now I am interpolating the density that is given by the user on a regular grid to the stagger points where the derivative is evaluated. Then I am using that interpolated model as the 'true density model'. This is a work-around which prevented me from having to rewrite the model parameter routine. It should be straight-forward to replace this interpolation step with a modified model parameter class that has density defined explicitly on these stagger points. 

**What I did not do:**
-I did not change other elements in the 'composite matrices' K, C and M used for timestepping (and the equivalents for Helmholtz). Some of these use the centered Dx operators. I have not tested or thought about what the consistency implications could be
-Did not implement anything other than 2D (the old derivative operators were also hardcoded for 2D). Extension to 1D and 3D is straight-forward however.
-Did not implement anything other than PML or Dirichlet boundary conditions (No Neumann
-I did not update the linear forward model and adjoint model routines! They still use the old 2nd order accurate differencing operators. For my research I do not need to form the VDA gradients, but the person who would need it would still have to do it him/herself.
-I did not implement CPP versions. The original VDA code did not have a complete CPP implementation either I believe so no functionality is broken

**Observations:**
-VDA Laplacian is self-adjoint. The only deviations from symmetry are around the boundary nodes because of the way Dirichlet is implemented. The same is the case in CDA
-VDA is same as CDA solver when second order accurate in space on uniform density model. See the test I added.
-VDA Laplacian has more bands than the CDA Laplacian, which would push cost by almost a factor of 2. This is the price we pay with the current implementation ? I wrote a VDA Laplacian before with the same number of bands as the CDA Laplacian, but it was not self-adjoint. 

Running the test may prove useful for you when evaluating whether this implementation has merit. Since at 2nd order accuracy the same results are obtained as in the old implementation (but at much higher speed) and arbitrary orders of accuracy still give self-adjoint Laplacians, I think this may be a good first step in improving the VDA functionality of PySIT.

I'm sure I forgot things in the description above. Shoot me a message anytime and I can give some feedback, although the sooner it happens the fresher the details are in my mind of course.

sincerely
Bram