### PR TITLE
Fix segy.core import from obspy

### DIFF
--- a/pysit/util/io.py
+++ b/pysit/util/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import obspy.segy.core as segy
+import obspy.io.segy.core as segy
 
 __all__ = ['read_model']
 


### PR DESCRIPTION
I cloned the repository, installed all the dependencies and ran ``python setup.py`` to install pysit on my computer. I then tried to run the example ``HorizontalReflector2D.py`` but got the following error message
```
Traceback (most recent call last):
  File "HorizontalReflector2D.py", line 8, in <module>
    from pysit.gallery import horizontal_reflector
  File "/home/anparis/Documents/master-thesis/src/venv/local/lib/python2.7/site-packages/pysit-0.6.dev0-py2.7-linux-x86_64.egg/pysit/gallery/__init__.py", line 1, in <module>
    from horizontal_reflector import *
  File "/home/anparis/Documents/master-thesis/src/venv/local/lib/python2.7/site-packages/pysit-0.6.dev0-py2.7-linux-x86_64.egg/pysit/gallery/horizontal_reflector.py", line 5, in <module>
    from pysit.gallery.gallery_base import GeneratedGalleryModel
  File "/home/anparis/Documents/master-thesis/src/venv/local/lib/python2.7/site-packages/pysit-0.6.dev0-py2.7-linux-x86_64.egg/pysit/gallery/gallery_base.py", line 14, in <module>
    from pysit.util.io import read_model
  File "/home/anparis/Documents/master-thesis/src/venv/local/lib/python2.7/site-packages/pysit-0.6.dev0-py2.7-linux-x86_64.egg/pysit/util/io.py", line 3, in <module>
    import obspy.segy.core as segy
ImportError: No module named segy.core
```
It seems ``segy.core`` is in ``obspy.io`` (maybe it was moved in a recent version). This pull request fix this issue and allow to successfully run ``HorizontalReflector2D.py``.

PS. git indicates 12 additions and 12 deletions because the original file does not contain a newline at end of file.