### PR TITLE
Modification of the Petsc function name in /util/wrappers/petsc.py

### DIFF
--- a/pysit/util/wrappers/petsc.py
+++ b/pysit/util/wrappers/petsc.py
@@ -57,7 +57,8 @@ class PetscWrapper():
         pc = ksp.getPC()
         pc.setType('lu') # setting the preconditioner to use an LU factorization
 
-        pc.setFactorSolverPackage(self.solverType) # using mumps as a sparse algorithm
+        # pc.setFactorSolverPackage(self.solverType) # using mumps as a sparse algorithm
+        pc.setFactorSolverType(self.solverType)
 
         # setting the solvers from the options
         pc.setFromOptions()


### PR DESCRIPTION
Petsc changes the function name of "setFactorSolverPackage" to "setFactorSolverType". Therefore, in order to use Petsc properly, we should make the corresponding changes in the file of '/util/wrappers/petsc.py'.